### PR TITLE
DO USUNIĘCIA

### DIFF
--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -21,6 +21,9 @@ from django.template.defaultfilters import truncatechars
 from django.test.utils import CaptureQueriesContext as BaseCaptureQueriesContext
 from django.utils import timezone
 from django_countries import countries
+from django.db import connection
+from django.db.models.signals import pre_migrate
+from django.dispatch import receiver
 from PIL import Image
 from prices import Money, TaxedMoney, fixed_discount
 
@@ -4223,3 +4226,11 @@ def app_export_event(app_export_file):
         app=app_export_file.app,
         parameters={"message": "Example error message"},
     )
+
+
+@receiver(pre_migrate)
+def install_extensions(sender, **kwargs):
+    with connection.cursor() as cursor:
+        cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+        cursor.execute("CREATE EXTENSION IF NOT EXISTS hstore;")
+        cursor.execute("CREATE EXTENSION IF NOT EXISTS btree_gin;")


### PR DESCRIPTION
I want to merge this change because...

To link payment together on Adyen side, during the payment we need to provide merchantOrderReference to each payment request which we send to Adyen. https://docs.adyen.com/api-explorer/#/CheckoutService/v67/post/payments__reqParam_merchantOrderReference

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
