### PR TITLE
Pass checkout_info and lines through manager to payload serializer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3.8

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -263,7 +263,10 @@ def fetch_checkout_prices_if_expired(
         checkout, manager, checkout_info, lines, address, discounts
     )
 
-    tax_data = manager.get_taxes_for_checkout(checkout)
+    tax_data = manager.get_taxes_for_checkout(
+        checkout_info,
+        lines,
+    )
     if tax_data:
         _apply_tax_data(checkout, lines, tax_data)
 

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -510,9 +510,7 @@ def get_valid_external_shipping_method_list_for_checkout_info(
     manager: "PluginsManager",
 ) -> List["ShippingMethodData"]:
 
-    return manager.list_shipping_methods_for_checkout(
-        checkout=checkout_info.checkout, channel_slug=checkout_info.channel.slug
-    )
+    return manager.list_shipping_methods_for_checkout(checkout_info, lines)
 
 
 def update_delivery_method_lists_for_checkout_info(
@@ -552,7 +550,7 @@ def update_delivery_method_lists_for_checkout_info(
         )
         # Filter shipping methods using sync webhooks
         excluded_methods = manager.excluded_shipping_methods_for_checkout(
-            checkout_info.checkout, all_methods
+            checkout_info, lines, all_methods
         )
         initialize_shipping_method_active_status(all_methods, excluded_methods)
         return all_methods

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -91,7 +91,8 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
         cls, info, shipping_method_id, checkout_info, lines, checkout, manager
     ):
         delivery_method = manager.get_shipping_method(
-            checkout=checkout,
+            checkout_info=checkout_info,
+            lines=lines,
             channel_slug=checkout.channel.slug,
             shipping_method_id=shipping_method_id,
         )

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -193,7 +193,8 @@ class CheckoutShippingMethodUpdate(BaseMutation):
         cls, info, shipping_method_id, checkout_info, lines, checkout, manager
     ):
         delivery_method = manager.get_shipping_method(
-            checkout=checkout,
+            checkout_info=checkout_info,
+            lines=lines,
             channel_slug=checkout.channel.slug,
             shipping_method_id=shipping_method_id,
         )

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -340,7 +340,10 @@ class BasePlugin:
         Any,
     ]
 
-    get_taxes_for_checkout: Callable[["Checkout", Any], Optional["TaxData"]]
+    get_taxes_for_checkout: Callable[
+        ["CheckoutInfo", Iterable["CheckoutLineInfo"], Any],
+        Optional["TaxData"],
+    ]
 
     get_taxes_for_order: Callable[["Order", Any], Optional["TaxData"]]
 
@@ -355,7 +358,8 @@ class BasePlugin:
     get_payment_config: Callable[[Any], Any]
 
     get_shipping_methods_for_checkout: Callable[
-        ["Checkout", Any], List["ShippingMethodData"]
+        ["CheckoutInfo", Iterable["CheckoutLineInfo"], Any],
+        List["ShippingMethodData"],
     ]
 
     get_supported_currencies: Callable[[Any], Any]

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -295,9 +295,9 @@ class PluginSample(BasePlugin):
         return Decimal("0.080").quantize(Decimal(".01"))
 
     def get_taxes_for_checkout(
-        self, checkout: "Checkout", previous_value
+        self, checkout_info: "CheckoutInfo", lines, previous_value
     ) -> Optional["TaxData"]:
-        return sample_tax_data(checkout)
+        return sample_tax_data(checkout_info.checkout)
 
     def get_taxes_for_order(
         self, order: "Order", previous_value

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -548,8 +548,11 @@ def test_manager_get_taxes_for_checkout(
     plugins,
     expected_tax_data,
 ):
+    lines, _ = fetch_checkout_lines(checkout)
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     assert PluginsManager(plugins=plugins).get_taxes_for_checkout(
-        checkout
+        checkout_info, lines
     ) == expected_tax_data(checkout)
 
 

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
 from django.core.cache import cache
 
@@ -63,6 +63,7 @@ from .utils import (
 
 if TYPE_CHECKING:
     from ...account.models import User
+    from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ...checkout.models import Checkout
     from ...discount.models import Sale
     from ...graphql.discount.mutations import NodeCatalogueInfo
@@ -616,11 +617,15 @@ class WebhookPlugin(BasePlugin):
         )
 
     def get_taxes_for_checkout(
-        self, checkout: "Checkout", previous_value
+        self, checkout_info, lines, previous_value
     ) -> Optional["TaxData"]:
         return trigger_all_webhooks_sync(
             WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
-            lambda: generate_checkout_payload_without_taxes(checkout, self.requestor),
+            lambda: generate_checkout_payload_without_taxes(
+                checkout_info,
+                lines,
+                self.requestor,
+            ),
             parse_tax_data,
         )
 
@@ -634,14 +639,19 @@ class WebhookPlugin(BasePlugin):
         )
 
     def get_shipping_methods_for_checkout(
-        self, checkout: "Checkout", previous_value: Any
+        self,
+        checkout_info: "CheckoutInfo",
+        lines: Iterable["CheckoutLineInfo"],
+        previous_value: Any,
     ) -> List["ShippingMethodData"]:
         methods = []
         apps = App.objects.for_event_type(
             WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
         ).prefetch_related("webhooks")
         if apps:
-            payload = generate_checkout_payload_without_taxes(checkout, self.requestor)
+            payload = generate_checkout_payload_without_taxes(
+                checkout_info, lines, self.requestor
+            )
             for app in apps:
                 response_data = trigger_webhook_sync(
                     event_type=WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
@@ -772,16 +782,17 @@ class WebhookPlugin(BasePlugin):
 
     def excluded_shipping_methods_for_checkout(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
+        lines: Iterable["CheckoutLineInfo"],
         available_shipping_methods: List["ShippingMethodData"],
         previous_value: List[ExcludedShippingMethod],
     ) -> List[ExcludedShippingMethod]:
-        generate_function = generate_excluded_shipping_methods_for_checkout_payload
-        payload_function = lambda: generate_function(  # noqa: E731
-            checkout,
-            available_shipping_methods,
-        )
-        cache_key = CACHE_EXCLUDED_SHIPPING_KEY + str(checkout.token)
+        def payload_function():
+            return generate_excluded_shipping_methods_for_checkout_payload(
+                checkout_info, lines, available_shipping_methods
+            )
+
+        cache_key = CACHE_EXCLUDED_SHIPPING_KEY + str(checkout_info.checkout.token)
         return get_excluded_shipping_data(
             event_type=WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
             previous_value=previous_value,

--- a/saleor/plugins/webhook/tests/test_shipping_exclude_cache.py
+++ b/saleor/plugins/webhook/tests/test_shipping_exclude_cache.py
@@ -3,7 +3,10 @@ from unittest import mock
 
 import graphene
 
+from saleor.checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+
 from ...base_plugin import ExcludedShippingMethod
+from ...manager import get_plugins_manager
 from ..const import CACHE_EXCLUDED_SHIPPING_KEY, CACHE_EXCLUDED_SHIPPING_TIME
 
 
@@ -227,12 +230,18 @@ def test_excluded_shipping_methods_for_checkout_use_cache(
         ExcludedShippingMethod(id="1", reason=other_reason),
         ExcludedShippingMethod(id="2", reason=other_reason),
     ]
+    lines, _ = fetch_checkout_lines(checkout_with_items)
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
+
     # when
     plugin.excluded_shipping_methods_for_checkout(
-        checkout=checkout_with_items,
+        checkout_info,
+        lines,
         available_shipping_methods=available_shipping_methods,
         previous_value=previous_value,
     )
+
     # then
     assert not mocked_webhook.called
 
@@ -281,12 +290,18 @@ def test_excluded_shipping_methods_for_checkout_stores_in_cache_when_empty(
         ExcludedShippingMethod(id="1", reason=other_reason),
         ExcludedShippingMethod(id="2", reason=other_reason),
     ]
+    lines, _ = fetch_checkout_lines(checkout_with_items)
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
+
     # when
     plugin.excluded_shipping_methods_for_checkout(
-        checkout=checkout_with_items,
+        checkout_info,
+        lines,
         available_shipping_methods=available_shipping_methods,
         previous_value=previous_value,
     )
+
     # then
     assert mocked_webhook.called
 
@@ -347,8 +362,12 @@ def test_excluded_shipping_methods_for_checkout_stores_in_cache_when_payload_dif
         ExcludedShippingMethod(id="2", reason=other_reason),
     ]
     # when
+    lines, _ = fetch_checkout_lines(checkout_with_items)
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
     plugin.excluded_shipping_methods_for_checkout(
-        checkout=checkout_with_items,
+        checkout_info,
+        lines,
         available_shipping_methods=available_shipping_methods,
         previous_value=previous_value,
     )

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -20,6 +20,7 @@ from ....account.notifications import (
     send_account_confirmation,
 )
 from ....app.models import App
+from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....core import EventDeliveryStatus
 from ....core.models import EventDelivery, EventDeliveryAttempt, EventPayload
 from ....core.notification.utils import get_site_context
@@ -657,8 +658,10 @@ def test_get_shipping_methods_for_checkout_uses_untaxed_payload_serializer(
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
-    manager.list_shipping_methods_for_checkout(checkout)
-    expected_data = generate_checkout_payload_without_taxes(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    manager.list_shipping_methods_for_checkout(checkout_info, lines)
+    expected_data = generate_checkout_payload_without_taxes(checkout_info, lines)
 
     mocked_webhook_trigger.assert_called_once_with(
         event_type=WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -655,14 +655,18 @@ def test_get_shipping_methods_for_checkout_uses_untaxed_payload_serializer(
     shipping_app,
     permission_manage_shipping,
 ):
+    # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
-    manager.list_shipping_methods_for_checkout(checkout_info, lines)
-    expected_data = generate_checkout_payload_without_taxes(checkout_info, lines)
 
+    # when
+    manager.list_shipping_methods_for_checkout(checkout_info, lines)
+
+    # then
+    expected_data = generate_checkout_payload_without_taxes(checkout_info, lines)
     mocked_webhook_trigger.assert_called_once_with(
         event_type=WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
         data=expected_data,

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -1148,10 +1148,13 @@ def generate_excluded_shipping_methods_for_order_payload(
 
 @traced_payload_generator
 def generate_excluded_shipping_methods_for_checkout_payload(
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
     available_shipping_methods: List[ShippingMethodData],
 ):
-    checkout_data = json.loads(generate_checkout_payload_without_taxes(checkout))[0]
+    checkout_data = json.loads(
+        generate_checkout_payload_without_taxes(checkout_info, lines)
+    )[0]
     payload = {
         "checkout": checkout_data,
         "shipping_methods": [
@@ -1314,10 +1317,11 @@ def generate_checkout_payload(
 
 
 def generate_checkout_payload_without_taxes(
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
     requestor: Optional["RequestorOrLazyObject"] = None,
 ):
-    lines, _ = fetch_checkout_lines(checkout, prefetch_variant_attributes=True)
+    checkout = checkout_info.checkout
     included_taxes_in_prices = include_taxes_in_prices()
 
     return _generate_checkout_payload(

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -15,6 +15,7 @@ from measurement.measures import Weight
 from prices import Money
 
 from ... import __version__
+from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...core.prices import quantize_price
 from ...core.taxes import include_taxes_in_prices
 from ...core.utils.json_serializer import CustomJsonEncoder
@@ -1361,8 +1362,11 @@ def test_generate_checkout_payload_without_taxes(
     mocked_serialize.return_value = serialized_checkout_lines
 
     # when
+    lines, _ = fetch_checkout_lines(checkout_with_prices)
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout_with_prices, lines, [], manager)
     payload = json.loads(
-        generate_checkout_payload_without_taxes(checkout, customer_user)
+        generate_checkout_payload_without_taxes(checkout_info, lines, customer_user)
     )[0]
 
     # then
@@ -1596,9 +1600,12 @@ def test_generate_excluded_shipping_methods_for_checkout(mocked_fetch, checkout)
         maximum_delivery_days=10,
         minimum_delivery_days=2,
     )
+    lines, _ = fetch_checkout_lines(checkout)
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     response = json.loads(
         generate_excluded_shipping_methods_for_checkout_payload(
-            checkout, [shipping_method]
+            checkout_info, lines, [shipping_method]
         )
     )
 

--- a/saleor/webhook/tests/test_webhook_serializers.py
+++ b/saleor/webhook/tests/test_webhook_serializers.py
@@ -6,6 +6,7 @@ import pytest
 
 from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...core.prices import quantize_price
+from ...discount.utils import fetch_active_discounts
 from ...plugins.manager import get_plugins_manager
 from ..serializers import (
     get_base_price,
@@ -90,11 +91,12 @@ def test_serialize_checkout_lines_with_taxes(
     checkout = checkout_with_prices
     lines, _ = fetch_checkout_lines(checkout)
     manager = get_plugins_manager()
+    discounts = fetch_active_discounts()
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     # when
     checkout_lines_data = serialize_checkout_lines_with_taxes(
-        checkout_info, manager, lines, []
+        checkout_info, manager, lines, discounts
     )
 
     # then


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
